### PR TITLE
SummonerId로 유저 puuid 가져오기 함수 추가(소환사명 변경 시 에러 발생)

### DIFF
--- a/RiotAPI.py
+++ b/RiotAPI.py
@@ -4,7 +4,7 @@ import numpy as np
 
 pp = pprint.PrettyPrinter(indent=4)
 # 24시간마다 변경해야 함
-api_key = 'RGAPI-60b643c9-a962-4629-a99c-84c1c3342849'
+api_key = 'RGAPI-887c4dda-af42-4fc1-aa2d-a14186f134cc'
 request_header = {
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36",
     "Accept-Language": "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7",
@@ -13,12 +13,16 @@ request_header = {
     "X-Riot-Token": api_key
 }
 
-# 유저 puuid 가져오기
+# 소환사명으로 유저 puuid 가져오기
 def getUserPuuid(summonerName):
     url = f"https://kr.api.riotgames.com/lol/summoner/v4/summoners/by-name/{summonerName}?{api_key}"
     return requests.get(url, headers=request_header).json()['puuid']
 # print(get_userPuuid('청파소나타')['puuid'])
 
+# SummonerId로 유저 puuid 가져오기
+def getUserPuuidBySummonerId(SummonerId):
+    url = f"https://kr.api.riotgames.com/lol/summoner/v4/summoners/{SummonerId}?{api_key}"
+    return requests.get(url, headers=request_header).json()['puuid']
 
 # 게임 match_id 찾기
 def getMatchId(puuid, start, count):
@@ -256,7 +260,7 @@ def getDataSet(matchId, frame):
 
 
 
-pp.pprint(getDataSet('KR_6709504031', 15))
+pp.pprint(getDataSet('KR_6710383118', 15))
 
 
 # [0]['participantId']

--- a/RiotAPIToCsv.py
+++ b/RiotAPIToCsv.py
@@ -1,0 +1,25 @@
+import requests
+import time
+import RiotAPI
+
+challengerPuuidList = []
+challengerMatchIdSet = set()
+
+# 챌린저 소환사 정보 가져오기
+def getChallengerEntries():
+    url = f"https://kr.api.riotgames.com/lol/league/v4/challengerleagues/by-queue/RANKED_SOLO_5x5?api_key{RiotAPI.api_key}"
+    return requests.get(url, headers=RiotAPI.request_header).json()['entries']
+
+# 챌린저 소환사 Puuid 가져오기
+for entry in getChallengerEntries():
+    challengerPuuidList.append(RiotAPI.getUserPuuidBySummonerId(entry['summonerId']))
+
+    # Riot API는 120분 / 100개 요청까지 허용하기 때문에 120÷100=1.2에 오차 0.1을 더해 1.3초마다 요청을 수행하도록 함
+    time.sleep(1.3)
+
+# 챌린저 matchId 가져오기(중복제거)
+for puuid in challengerPuuidList:
+    challengerMatchIdSet.update(RiotAPI.getMatchId(puuid, 0, 20))
+    time.sleep(1.3)
+
+print(len(challengerMatchIdSet))


### PR DESCRIPTION
기존 getUserPuuid 함수 사용 시 프로그램 동작 중 소환사 명이 변경 될 경우 오류 발생.
getUserPuuidBySummonerId 함수 추가하여 소환사명이 변경돼도 오류 없도록 조치